### PR TITLE
Replace componentWillUpdate with getDerivedStateFromProps

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,10 @@ var ImageLoader = function (_React$Component) {
 
     var _this = _possibleConstructorReturn(this, (ImageLoader.__proto__ || Object.getPrototypeOf(ImageLoader)).call(this, props));
 
-    _this.state = { status: props.src ? Status.LOADING : Status.PENDING };
+    _this.state = {
+      status: props.src ? Status.LOADING : Status.PENDING,
+      src: props.src
+    };
     if (_react2.default.Children.count(props.children) !== 3) console.error('wrong # of children provided to ImageLoader');
     return _this;
   }
@@ -49,15 +52,6 @@ var ImageLoader = function (_React$Component) {
     value: function componentDidMount() {
       if (this.state.status === Status.LOADING) {
         this.createLoader();
-      }
-    }
-  }, {
-    key: 'componentWillReceiveProps',
-    value: function componentWillReceiveProps(nextProps) {
-      if (this.props.src !== nextProps.src) {
-        this.setState({
-          status: nextProps.src ? Status.LOADING : Status.PENDING
-        });
       }
     }
   }, {
@@ -139,6 +133,17 @@ var ImageLoader = function (_React$Component) {
         this.state.status === Status.FAILED && childrenArray[1],
         (this.state.status === Status.LOADING || this.state.status === Status.PENDING) && childrenArray[2]
       );
+    }
+  }], [{
+    key: 'getDerivedStateFromProps',
+    value: function getDerivedStateFromProps(nextProps, prevState) {
+      if (prevState.src !== nextProps.src) {
+        return {
+          status: nextProps.src ? Status.LOADING : Status.PENDING,
+          src: nextProps.src
+        };
+      }
+      return null;
     }
   }]);
 

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,10 @@ export default class ImageLoader extends React.Component {
 
   constructor(props) {
     super(props);
-    this.state = {status: props.src ? Status.LOADING : Status.PENDING};
+    this.state = {
+      status: props.src ? Status.LOADING : Status.PENDING,
+      src: props.src
+    };
     if(React.Children.count(props.children) !== 3)
       console.error('wrong # of children provided to ImageLoader')
   }
@@ -31,12 +34,14 @@ export default class ImageLoader extends React.Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (this.props.src !== nextProps.src) {
-      this.setState({
+  static getDerivedStateFromProps(nextProps, prevState) {
+    if (prevState.src !== nextProps.src) {
+      return {
         status: nextProps.src ? Status.LOADING : Status.PENDING,
-      });
+        src: nextProps.src
+      };
     }
+    return null;
   }
 
   componentDidUpdate() {


### PR DESCRIPTION
From the React docs: componentWillReceiveProps has been renamed, and is not recommended for use.
To remove the warning messages and ensure that react-load-image continues to work in React v17, this update replaces it with getDerivedStateFromProps()